### PR TITLE
Backport M1 arch detection fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ build environments.
 
 ## Usage
 
-Put `[com.circleci/lein-protoc "0.6.0"]` into the `:plugins` vector of your project.clj.
+Put `[com.circleci/lein-protoc "0.6.1"]` into the `:plugins` vector of your project.clj.
 
 The following options can be configured in the project.clj:
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.circleci/lein-protoc "0.6.0"
+(defproject com.circleci/lein-protoc "0.6.1"
   :description "Leiningen plugin for compiling Protocol Buffers"
   :url "https://github.com/LiaisonTechnologies/lein-protoc"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/protoc.clj
+++ b/src/leiningen/protoc.clj
@@ -193,9 +193,12 @@
 
 (defn get-arch
   []
-  (if-let [arch (leiningen.core.utils/get-arch)]
-    (name (if (= arch :x86) :x86_32 arch))
-    (throw (Exception. "Leiningen failed to detect the processor architecture"))))
+  ;; backport fix from leiningen: https://github.com/technomancy/leiningen/commit/60f7ab7cb132ad5e495688ec4f066a575c9996c9
+  (let [native-names-updated (assoc @#'leiningen.core.utils/native-names "aarch64" :aarch_64)]
+    (with-redefs [leiningen.core.utils/native-names native-names-updated]
+      (if-let [arch (leiningen.core.utils/get-arch)]
+        (name (if (= arch :x86) :x86_32 arch))
+        (throw (Exception. "Leiningen failed to detect the processor architecture"))))))
 
 (defn resolve-classifier
   "Versions of com.google.protobuf/protoc prior to 3.17.3 don't ship binaries


### PR DESCRIPTION
This allows our lein-protoc fork to be used with the current stable lein version. 